### PR TITLE
Fix session restart and auto-detect new question files

### DIFF
--- a/client/pages/Results.tsx
+++ b/client/pages/Results.tsx
@@ -33,9 +33,12 @@ export default function ResultsPage() {
     );
   }
 
-  const { details, score, total, sessionIndex = 0, totalSessions = 1 } = state;
+  const { details, score, total, sessionIndex = 0, totalSessions = 1, sessionParam } = state as any;
   const percent = Math.round((score / total) * 100);
   const hasNext = sessionIndex < totalSessions - 1;
+
+  // If the original session was a filename (non-numeric), prefer restarting that exact file
+  const isFileSession = typeof sessionParam === "string" && !/^[0-9]+$/.test(sessionParam);
 
   return (
     <div className="container max-w-4xl py-8">
@@ -46,18 +49,26 @@ export default function ResultsPage() {
         </p>
         <div className="mt-4 flex gap-3">
           <Button
-            onClick={() =>
-              navigate(
-                `/test?session=${hasNext ? sessionIndex + 1 : sessionIndex}`,
-              )
-            }
+            onClick={() => {
+              if (isFileSession) {
+                navigate(`/test?session=${encodeURIComponent(sessionParam)}`);
+              } else {
+                navigate(`/test?session=${hasNext ? sessionIndex + 1 : sessionIndex}`);
+              }
+            }}
           >
             {hasNext ? "Next Session" : "Restart Test"}
           </Button>
           {hasNext && (
             <Button
               variant="secondary"
-              onClick={() => navigate(`/test?session=${sessionIndex}`)}
+              onClick={() => {
+                if (isFileSession) {
+                  navigate(`/test?session=${encodeURIComponent(sessionParam)}`);
+                } else {
+                  navigate(`/test?session=${sessionIndex}`);
+                }
+              }}
             >
               Restart
             </Button>

--- a/client/pages/Results.tsx
+++ b/client/pages/Results.tsx
@@ -33,12 +33,20 @@ export default function ResultsPage() {
     );
   }
 
-  const { details, score, total, sessionIndex = 0, totalSessions = 1, sessionParam } = state as any;
+  const {
+    details,
+    score,
+    total,
+    sessionIndex = 0,
+    totalSessions = 1,
+    sessionParam,
+  } = state as any;
   const percent = Math.round((score / total) * 100);
   const hasNext = sessionIndex < totalSessions - 1;
 
   // If the original session was a filename (non-numeric), prefer restarting that exact file
-  const isFileSession = typeof sessionParam === "string" && !/^[0-9]+$/.test(sessionParam);
+  const isFileSession =
+    typeof sessionParam === "string" && !/^[0-9]+$/.test(sessionParam);
 
   return (
     <div className="container max-w-4xl py-8">
@@ -53,7 +61,9 @@ export default function ResultsPage() {
               if (isFileSession) {
                 navigate(`/test?session=${encodeURIComponent(sessionParam)}`);
               } else {
-                navigate(`/test?session=${hasNext ? sessionIndex + 1 : sessionIndex}`);
+                navigate(
+                  `/test?session=${hasNext ? sessionIndex + 1 : sessionIndex}`,
+                );
               }
             }}
           >

--- a/client/pages/Results.tsx
+++ b/client/pages/Results.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { useNavigate, useLocation } from "react-router-dom";
 
 export default function ResultsPage() {
   const navigate = useNavigate();

--- a/client/pages/Results.tsx
+++ b/client/pages/Results.tsx
@@ -1,6 +1,5 @@
-import { useLocation, useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
 import { useNavigate, useLocation } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 
 export default function ResultsPage() {
   const navigate = useNavigate();

--- a/client/pages/Test.tsx
+++ b/client/pages/Test.tsx
@@ -121,7 +121,14 @@ export default function TestPage() {
     });
     const score = details.filter((d) => d.correct).length;
     navigate("/results", {
-      state: { details, score, total, sessionIndex, totalSessions },
+      state: {
+        details,
+        score,
+        total,
+        sessionIndex,
+        totalSessions,
+        sessionParam: rawSession,
+      },
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "vite",
     "build": "npm run build:client && npm run build:server",
+    "prebuild:client": "node scripts/generate-question-sets.mjs",
     "build:client": "vite build",
     "build:server": "vite build --config vite.config.server.ts",
     "start": "node dist/server/node-build.mjs",

--- a/scripts/generate-question-sets.mjs
+++ b/scripts/generate-question-sets.mjs
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+try {
+  const cwd = process.cwd();
+  const publicDir = path.resolve(cwd, "public");
+  if (!fs.existsSync(publicDir)) {
+    console.error(`Public directory not found at ${publicDir}`);
+    process.exit(0);
+  }
+
+  const files = fs.readdirSync(publicDir);
+  const sets = files
+    .filter((f) => /Questions\.json$/i.test(f))
+    .sort((a, b) => a.localeCompare(b))
+    .map((filename) => ({
+      filename,
+      url: `/${encodeURI(filename)}`,
+      title: filename.replace(/\.json$/i, ""),
+    }));
+
+  const outPath = path.join(publicDir, "question-sets.json");
+  fs.writeFileSync(outPath, JSON.stringify(sets, null, 2));
+  console.log(`Generated ${outPath} with ${sets.length} entries.`);
+} catch (e) {
+  console.error("Failed to generate question-sets.json:", e);
+  process.exit(1);
+}

--- a/scripts/generate-question-sets.mjs
+++ b/scripts/generate-question-sets.mjs
@@ -21,7 +21,8 @@ try {
     }
   });
 
-  withStat.sort((a, b) => b.mtime - a.mtime);
+  // Sort ascending by mtime (oldest first) so newest appear last
+  withStat.sort((a, b) => a.mtime - b.mtime);
 
   const sets = withStat.map(({ filename }) => ({
     filename,

--- a/server/routes/question-sets.ts
+++ b/server/routes/question-sets.ts
@@ -9,7 +9,7 @@ export const handleQuestionSets: RequestHandler = (_req, res) => {
     const files = fs.readdirSync(publicDir);
     const filtered = files.filter((f) => /Questions\.json$/i.test(f));
 
-    // Attach file mtime and sort by newest first so UI shows latest uploads first
+    // Attach file mtime and sort oldest-first so the newest files appear last in the UI
     const withStat = filtered.map((filename) => {
       try {
         const stat = fs.statSync(path.join(publicDir, filename));
@@ -19,7 +19,8 @@ export const handleQuestionSets: RequestHandler = (_req, res) => {
       }
     });
 
-    withStat.sort((a, b) => b.mtime - a.mtime);
+    // Sort ascending by mtime (oldest first)
+    withStat.sort((a, b) => a.mtime - b.mtime);
 
     const sets = withStat.map(({ filename }) => ({
       filename,

--- a/server/routes/question-sets.ts
+++ b/server/routes/question-sets.ts
@@ -7,13 +7,26 @@ export const handleQuestionSets: RequestHandler = (_req, res) => {
     const publicDir = path.resolve(process.cwd(), "public");
     if (!fs.existsSync(publicDir)) return res.json([]);
     const files = fs.readdirSync(publicDir);
-    const sets = files
-      .filter((f) => /Questions\.json$/i.test(f))
-      .map((filename) => ({
-        filename,
-        url: `/${encodeURI(filename)}`,
-        title: filename.replace(/\.json$/i, ""),
-      }));
+    const filtered = files.filter((f) => /Questions\.json$/i.test(f));
+
+    // Attach file mtime and sort by newest first so UI shows latest uploads first
+    const withStat = filtered.map((filename) => {
+      try {
+        const stat = fs.statSync(path.join(publicDir, filename));
+        return { filename, mtime: stat.mtimeMs };
+      } catch {
+        return { filename, mtime: 0 };
+      }
+    });
+
+    withStat.sort((a, b) => b.mtime - a.mtime);
+
+    const sets = withStat.map(({ filename }) => ({
+      filename,
+      url: `/${encodeURI(filename)}`,
+      title: filename.replace(/\.json$/i, ""),
+    }));
+
     res.json(sets);
   } catch (e: any) {
     res.status(500).json({ error: e?.message ?? String(e) });


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several key issues:
- Auto-detection of new question JSON files when rebuilding on Netlify
- Sorting sessions by file creation time with newest files appearing last
- Fixing session restart functionality to continue with the same question set instead of starting a new one
- Resolving runtime errors related to session handling

## Code changes

**Question Set Auto-Detection:**
- Added `generate-question-sets.mjs` script to automatically scan and generate question sets from `/public` directory
- Added `prebuild:client` script to run question set generation before client build
- Modified question sets API endpoint to sort files by modification time (oldest first, newest last)

**Session Restart Fix:**
- Enhanced `Results.tsx` to preserve original session parameter (`sessionParam`) 
- Added logic to detect filename-based sessions vs numeric sessions
- Updated restart buttons to use the original session parameter, ensuring users restart the same question set
- Modified `Test.tsx` to pass the raw session parameter to results page

**File Sorting:**
- Implemented file modification time sorting in both build script and API endpoint
- Newest question files now appear last in the dropdown as requestedTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/83cb48140e354a438cb592394a06f6a5/pixel-den)

👀 [Preview Link](https://83cb48140e354a438cb592394a06f6a5-pixel-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>83cb48140e354a438cb592394a06f6a5</projectId>-->
<!--<branchName>pixel-den</branchName>-->